### PR TITLE
correction message d'erreur

### DIFF
--- a/srcs/gnl/gnl7_3.c
+++ b/srcs/gnl/gnl7_3.c
@@ -40,9 +40,9 @@ int				main(void)
 		}
 		close(fd);
 		if (count_lines != 4)
-			printf("-> must have returned '1' four times instead of %d time(s)\n", count_lines);
+			printf("-> should have returned '1' four times instead of %d time(s)\n", count_lines);
 		if (errors > 0)
-			printf("-> must have read \"1234567\", \"abcdefg\", \"4567890\" and \"defghijk\"\n");
+			printf("-> should have read \"1234567\", \"abcdefg\", \"4567890\" and \"defghijk\"\n");
 		if (count_lines == 4 && errors == 0)
 			printf("OK\n");
 	}


### PR DESCRIPTION
must have veux dire "doit avoir" et should have "devrait". C'est a dire que le message d'erreur etait "doit avoir rendu '1' quatre fois[...]" au lieu de "devrait rendre '1' quatre fois[...]"