### PR TITLE
[FIX]Utils: Fix display not clearing

### DIFF
--- a/includes/utils/utils.sh
+++ b/includes/utils/utils.sh
@@ -252,7 +252,7 @@ then
     printf "${C_CLEAR}\n\n"
     [ "${GLOBAL_IS_INTERACTIVE}" == "0" ] && return
     tput cup 0 0
-    tput cd
+    tput ed
   }
 
   function check_cleanlog


### PR DESCRIPTION
Replacing 'tput cd' (termcap capabilities equivalent) by 'tput ed' (capabilities name)

cf: https://www.gnu.org/software/termutils/manual/termutils-2.0/html_chapter/tput_1.html
Fix #101