### PR TITLE
new test for GNL + display more info on compilation failure

### DIFF
--- a/42FileChecker.sh
+++ b/42FileChecker.sh
@@ -55,6 +55,7 @@ OPT_NO_FORBIDDEN=0
 OPT_NO_STATICDECLARATIONS=0
 OPT_NO_LIBFTFILESEXIST=0
 OPT_NO_GNLMULTIPLEFD=0
+OPT_NO_GNLTOFREEORNOTTOFREE=0
 OPT_NO_GNLONESTATIC=0
 OPT_NO_GNLMACRO=0
 OPT_NO_DISCLAIMER=0
@@ -90,6 +91,7 @@ do
     "--no-staticdeclarations") OPT_NO_STATICDECLARATIONS=1 ;;
     "--no-libftfilesexists") OPT_NO_LIBFTFILESEXIST=1 ;;
     "--no-gnlmultiplefd") OPT_NO_GNLMULTIPLEFD=1 ;;
+    "--no-gnltofreeornottofree") OPT_NO_GNLTOFREEORNOTTOFREE=1 ;;
     "--no-gnlonestatic") OPT_NO_GNLONESTATIC=1 ;;
     "--no-gnlmacro") OPT_NO_GNLMACRO=1 ;;
     "--no-disclaimer") OPT_NO_DISCLAIMER=1 ;;

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Do not display color tags.
 
 Disable timeout.
 
-##### `--no-disclaimer`, `--no-auteur`, `--no-author`, `--no-norminette`, `--no-leaks`, `--no-speedtest`, `--no-basictests`, `--no-makefile`, `--no-forbidden`, `--no-staticdeclarations`, `--no-libftfilesexists`, `--no-gnlmultiplefd`, `--no-gnlonestatic`, `--no-gnlmacro`, `--no-moulitest`, `--no-libftunittest`, `--no-fillitchecker`, `--no-maintest`, `--no-42shelltester`
+##### `--no-disclaimer`, `--no-auteur`, `--no-author`, `--no-norminette`, `--no-leaks`, `--no-speedtest`, `--no-basictests`, `--no-makefile`, `--no-forbidden`, `--no-staticdeclarations`, `--no-libftfilesexists`, `--no-gnlmultiplefd`, `--no-gnlonestatic`, `--no-gnlmacro`, `--no-gnltofreeornottofree`, `--no-moulitest`, `--no-libftunittest`, `--no-fillitchecker`, `--no-maintest`, `--no-42shelltester`
 
 Disable a specific test.
 

--- a/includes/projects/gnl/get_next_line_main.sh
+++ b/includes/projects/gnl/get_next_line_main.sh
@@ -11,9 +11,47 @@ then
   declare CONF_GNL_TESTS="CHK_GNL"
   declare CONF_GNL_FORBIDDENFUNCS="CHK_GNL_AUTHORIZED_FUNCS"
 
-  declare -a CHK_GNL='( "check_author" "author file" "check_norme" "norminette" "check_gnl_macro" "BUFF_SIZE macro" "check_gnl_bonus" "bonus: static var" "check_gnl_forbidden_func" "forbidden functions" "check_gnl_basics" "basic tests" "check_gnl_multiple_fd" "bonus: multiple file descriptor" "check_gnl_leaks" "leaks" "check_gnl_moulitest" "moulitest (${MOULITEST_URL})" )'
+  declare -a CHK_GNL='(
+    "check_author"                      "author file"
+    "check_norme"                       "norminette"
+    "check_gnl_macro"                   "BUFF_SIZE macro"
+    "check_gnl_bonus"                   "bonus: static var"
+    "check_gnl_forbidden_func"          "forbidden functions"
+    "check_gnl_basics"                  "basic tests"
+    "check_gnl_to_free_or_not_to_free"  "to free, or not to free"
+    "check_gnl_multiple_fd"             "bonus: multiple file descriptor"
+    "check_gnl_leaks"                   "leaks"
+    "check_gnl_moulitest"               "moulitest (${MOULITEST_URL})"
+  )'
 
-  declare -a CHK_GNL_BASICS='("gnl1_1" "1 line 8 chars with Line Feed" "" "gnl1_2" "2 lines 8 chars with Line Feed" "" "gnl1_3" "4 lines 8 chars with Line Feed" "" "gnl2_1" "STDIN: 1 line 8 chars with Line Feed" "cat ./srcs/gnl/gnl1_1.txt | SPEC0" "gnl2_2" "STDIN: 2 lines 8 chars with Line Feed" "cat ./srcs/gnl/gnl1_2.txt | SPEC0" "gnl2_3" "STDIN: 4 lines 8 chars with Line Feed" "cat ./srcs/gnl/gnl1_3.txt | SPEC0" "gnl3_1" "1 line 16 chars with Line Feed" "" "gnl3_2" "2 lines 16 chars with Line Feed" "" "gnl3_3" "4 lines 16 chars with Line Feed" "" "gnl4_1" "STDIN: 1 line 16 chars with Line Feed" "cat ./srcs/gnl/gnl3_1.txt | SPEC0" "gnl4_2" "STDIN: 2 lines 16 chars with Line Feed" "cat ./srcs/gnl/gnl3_2.txt | SPEC0" "gnl4_3" "STDIN: 4 lines 16 chars with Line Feed" "cat ./srcs/gnl/gnl3_3.txt | SPEC0" "gnl5_1" "1 line 4 chars with Line Feed" "" "gnl5_2" "2 lines 4 chars with Line Feed" "" "gnl5_3" "4 lines 4 chars with Line Feed" "" "gnl6_1" "STDIN: 1 line 4 chars with Line Feed" "cat ./srcs/gnl/gnl5_1.txt | SPEC0" "gnl6_2" "STDIN: 2 lines 4 chars with Line Feed" "cat ./srcs/gnl/gnl5_2.txt | SPEC0" "gnl6_3" "STDIN: 4 lines 4 chars with Line Feed" "cat ./srcs/gnl/gnl5_3.txt | SPEC0" "gnl7_1" "1 lines 8 chars without Line Feed" "" "gnl7_2" "2 lines 8 chars without Line Feed" "" "gnl7_3" "4 lines 8 chars without Line Feed" "" "gnl8_1" "STDIN: 1 line 8 chars without Line Feed" "cat ./srcs/gnl/gnl7_1.txt | SPEC0" "gnl8_2" "STDIN: 2 lines 8 chars without Line Feed" "cat ./srcs/gnl/gnl7_2.txt | SPEC0" "gnl8_3" "STDIN: 4 lines 8 chars without Line Feed" "cat ./srcs/gnl/gnl7_3.txt | SPEC0" "gnl9_1" "Bad file descriptor #1" "" "gnl9_2" "Bad file descriptor #2" "")'
+  declare -a CHK_GNL_BASICS='(
+    "gnl1_1" "1 line 8 chars with Line Feed"            ""
+    "gnl1_2" "2 lines 8 chars with Line Feed"           ""
+    "gnl1_3" "4 lines 8 chars with Line Feed"           ""
+    "gnl2_1" "STDIN: 1 line 8 chars with Line Feed"     "cat ./srcs/gnl/gnl1_1.txt | SPEC0"
+    "gnl2_2" "STDIN: 2 lines 8 chars with Line Feed"    "cat ./srcs/gnl/gnl1_2.txt | SPEC0"
+    "gnl2_3" "STDIN: 4 lines 8 chars with Line Feed"    "cat ./srcs/gnl/gnl1_3.txt | SPEC0"
+    "gnl3_1" "1 line 16 chars with Line Feed"           ""
+    "gnl3_2" "2 lines 16 chars with Line Feed"          ""
+    "gnl3_3" "4 lines 16 chars with Line Feed"          ""
+    "gnl4_1" "STDIN: 1 line 16 chars with Line Feed"    "cat ./srcs/gnl/gnl3_1.txt | SPEC0"
+    "gnl4_2" "STDIN: 2 lines 16 chars with Line Feed"   "cat ./srcs/gnl/gnl3_2.txt | SPEC0"
+    "gnl4_3" "STDIN: 4 lines 16 chars with Line Feed"   "cat ./srcs/gnl/gnl3_3.txt | SPEC0"
+    "gnl5_1" "1 line 4 chars with Line Feed"            ""
+    "gnl5_2" "2 lines 4 chars with Line Feed"           ""
+    "gnl5_3" "4 lines 4 chars with Line Feed"           ""
+    "gnl6_1" "STDIN: 1 line 4 chars with Line Feed"     "cat ./srcs/gnl/gnl5_1.txt | SPEC0"
+    "gnl6_2" "STDIN: 2 lines 4 chars with Line Feed"    "cat ./srcs/gnl/gnl5_2.txt | SPEC0"
+    "gnl6_3" "STDIN: 4 lines 4 chars with Line Feed"    "cat ./srcs/gnl/gnl5_3.txt | SPEC0"
+    "gnl7_1" "1 lines 8 chars without Line Feed"        ""
+    "gnl7_2" "2 lines 8 chars without Line Feed"        ""
+    "gnl7_3" "4 lines 8 chars without Line Feed"        ""
+    "gnl8_1" "STDIN: 1 line 8 chars without Line Feed"  "cat ./srcs/gnl/gnl7_1.txt | SPEC0"
+    "gnl8_2" "STDIN: 2 lines 8 chars without Line Feed" "cat ./srcs/gnl/gnl7_2.txt | SPEC0"
+    "gnl8_3" "STDIN: 4 lines 8 chars without Line Feed" "cat ./srcs/gnl/gnl7_3.txt | SPEC0"
+    "gnl9_1" "Bad file descriptor #1"                   ""
+    "gnl9_2" "Bad file descriptor #2"                   ""
+  )'
 
   function check_project_gnl_main
   {
@@ -40,8 +78,8 @@ then
 
     MYPATH=$(get_config "gnl")
     display_header
-    display_top "$MYPATH" GET_NEXT_LINE
-    if [ -d "$MYPATH" ]
+    display_top "${MYPATH}" GET_NEXT_LINE
+    if [ -d "${MYPATH}" ]
     then
       display_menu\
         ""\
@@ -81,6 +119,7 @@ then
       "open .mybonusstatic" "more info: bonus: static var"\
       "open .myforbiddenfunc" "more info: forbidden functions"\
       "open .mybasictests" "more info: basic tests"\
+      "open .mygnlfreeornottofree" "more info: to free, or not to free"\
       "open .mymultiplefd" "more info: bonus: multiple file descriptor"\
       "open .myleaks" "more info: leaks"\
       "open .mymoulitest" "more info: moulitest"\
@@ -92,12 +131,15 @@ then
 
   function check_gnl_forbidden_func
   {
-    local FILEN GNL_LIBFT RET0 SOURCEF
+    local FILEN GNL_LIBFT_DIRECTORY RET0 SOURCEF LOGFILENAME
 
     if [ "${OPT_NO_FORBIDDEN}" == "0" ]
     then
+      LOGFILENAME=".myforbiddenfunc"
+      ${CMD_RM} -f ${LOGFILENAME}
+      ${CMD_TOUCH} ${LOGFILENAME}
       FILEN=forbiddenfuncs
-      GNL_LIBFT="${MYPATH}/libft"
+      GNL_LIBFT_DIRECTORY="${MYPATH}/libft"
       SOURCEF="./tmp/${FILEN}.c"
       check_create_tmp_dir
       check_gnl_create_header
@@ -105,12 +147,13 @@ then
       echo "#include \"gnl.h\"" >> ${SOURCEF}
       echo "int main(void) { int ret; ret = get_next_line(0, NULL); return (1); }" >> ${SOURCEF}
       ${CMD_RM} -f "./tmp/${FILEN}"
-      if [ -d "${GNL_LIBFT}" ]
+      if [ -d "${GNL_LIBFT_DIRECTORY}" ]
       then
-        make -C "${GNL_LIBFT}" >/dev/null 2>&1
-        RET0=`${CMD_GCC} "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT}" -lft -I "${GNL_LIBFT}/includes" ./tmp/${FILEN}.c -o ./tmp/${FILEN} >/dev/null 2>&1`
+        make -C "${GNL_LIBFT_DIRECTORY}" >/dev/null 2>&1
+        [ ${?} != 0 ] && echo "/!\ Failed to compile libft while running: make -C \"${GNL_LIBFT_DIRECTORY}\"\n" >> ${LOGFILENAME}
+        RET0=`${CMD_GCC} "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT_DIRECTORY}" -lft -I "${GNL_LIBFT_DIRECTORY}/includes" ./tmp/${FILEN}.c -o ./tmp/${FILEN} >> ${LOGFILENAME} 2>&1`
       else
-        RET0=`${CMD_GCC} "${MYPATH}/get_next_line.c" ./tmp/${FILEN}.c -o ./tmp/${FILEN} >/dev/null 2>&1`
+        RET0=`${CMD_GCC} "${MYPATH}/get_next_line.c" ./tmp/${FILEN}.c -o ./tmp/${FILEN} >> ${LOGFILENAME} 2>&1`
       fi
       if [ -f "./tmp/${FILEN}" ]
       then
@@ -127,7 +170,7 @@ then
 
   function check_gnl_basics
   {
-    local GNL_LIBFT i j FILEN TITLEN RET0 errors fatal SPEC0 LOGFILENAME
+    local GNL_LIBFT_DIRECTORY i j FILEN TITLEN RET0 errors fatal SPEC0 LOGFILENAME
 
     if [ "${OPT_NO_BASICTESTS}" == "0" ]
     then
@@ -136,16 +179,17 @@ then
       ${CMD_TOUCH} ${LOGFILENAME}
       check_create_tmp_dir
       check_gnl_create_header
-      GNL_LIBFT="${MYPATH}/libft"
+      GNL_LIBFT_DIRECTORY="${MYPATH}/libft"
       i=0
       j=0
       errors=0
       fatal=0
-      if [ -d "${GNL_LIBFT}" ]
+      if [ -d "${GNL_LIBFT_DIRECTORY}" ]
       then
-        make -C "${GNL_LIBFT}" >/dev/null 2>&1
+        make -C "${GNL_LIBFT_DIRECTORY}" >/dev/null 2>&1
+        [ ${?} != 0 ] && echo "/!\ Failed to compile libft while running: make -C \"${GNL_LIBFT_DIRECTORY}\"\n" >> ${LOGFILENAME}
       fi
-      echo "GNL BASIC TESTS:\n" > ${LOGFILENAME}
+      echo "GNL BASIC TESTS:\n" >> ${LOGFILENAME}
       while [ "${CHK_GNL_BASICS[i]}" != "" ]
       do
         (( j += 1 ))
@@ -156,11 +200,11 @@ then
         SPEC0="${CHK_GNL_BASICS[i]}"
         (( i += 1 ))
         echo "---------------------" >> ${LOGFILENAME}
-        echo "TEST #$j: ${TITLEN} (${FILEN}.c):" >> ${LOGFILENAME}
+        echo "TEST #${j}: ${TITLEN} (${GLOBAL_INSTALLDIR}/${FILEN}.c):" >> ${LOGFILENAME}
         ${CMD_RM} -f "./tmp/${FILEN}"
-        if [ -d "${GNL_LIBFT}" ]
+        if [ -d "${GNL_LIBFT_DIRECTORY}" ]
         then
-          RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT}" -lft -I "${GNL_LIBFT}/includes" ./srcs/gnl/${FILEN}.c -o ./tmp/${FILEN} 2>&1`
+          RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT_DIRECTORY}" -lft -I "${GNL_LIBFT_DIRECTORY}/includes" ./srcs/gnl/${FILEN}.c -o ./tmp/${FILEN} 2>&1`
         else
           RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" ./srcs/gnl/${FILEN}.c -o ./tmp/${FILEN} 2>&1`
         fi
@@ -175,9 +219,7 @@ then
             then
               cp "./srcs/gnl/${FILEN}.txt" "./tmp/${FILEN}.txt"
             fi
-            cd "./tmp"
-            RET0=`./${FILEN} 2>&1`
-            cd ".."
+            RET0=`(cd ./tmp; ./${FILEN} 2>&1) 2>&1`
           fi
           if [ "${RET0}" != "OK" ]
           then
@@ -209,9 +251,89 @@ then
     return 255
   }
 
+  function check_gnl_to_free_or_not_to_free
+  {
+    local GNL_LIBFT_DIRECTORY LOGFILENAME EXECFILE SRCFILE ERRLOGFILENAME
+
+    if [ "${OPT_NO_GNLTOFREEORNOTTOFREE}" == "0" ]
+    then
+      SRCFILE="srcs/gnl/gnl_to_free_or_not_to_free.c"
+      EXECFILE="./tmp/gnl_to_free_or_not_to_free"
+      LOGFILENAME=".mygnlfreeornottofree"
+      ${CMD_RM} -f ${LOGFILENAME}
+      ${CMD_TOUCH} ${LOGFILENAME}
+      ERRLOGFILENAME=".mygnlfreeornottofree_errors"
+      ${CMD_RM} -f ${ERRLOGFILENAME}
+      ${CMD_TOUCH} ${ERRLOGFILENAME}
+      check_create_tmp_dir
+      check_gnl_create_header
+      GNL_LIBFT_DIRECTORY="${MYPATH}/libft"
+      ${CMD_RM} -f ${EXECFILE}
+      if [ -d "${GNL_LIBFT_DIRECTORY}" ]
+      then
+        make -C "${GNL_LIBFT_DIRECTORY}" >/dev/null 2>&1
+        [ ! "${?}" == 0 ] && echo "/!\ Failed to compile libft while running: make -C \"${GNL_LIBFT_DIRECTORY}\"\n" >> ${LOGFILENAME}
+        RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT_DIRECTORY}" -lft -I "${GNL_LIBFT_DIRECTORY}/includes" ${SRCFILE} -o ${EXECFILE} 2>&1`
+      else
+        RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" ${SRCFILE} -o ${EXECFILE} 2>&1`
+      fi
+      if [ -f ${EXECFILE} ]
+      then
+        cp "srcs/gnl/gnl_to_free_or_not_to_free.txt" "./tmp/gnl_to_free_or_not_to_free.txt"
+        RET0=`(cd ./tmp; ./gnl_to_free_or_not_to_free; ./gnl_to_free_or_not_to_free; ./gnl_to_free_or_not_to_free) 2>${ERRLOGFILENAME}`
+        RET2=`cat ${ERRLOGFILENAME}`
+        echo "The purpose of this test is to check wether get_next_line lets the caller freeing the lines itself after each call or not." >> ${LOGFILENAME}
+        echo "The subject does not tell you how to implement the memory management, so that both behaviors can be justified." >> ${LOGFILENAME}
+        if [ "${RET0}" == "OKOKOK" ]
+        then
+          printf "%s" 'Similar to `getline(3)`'
+          echo 'Result: The implementation of this get_next_line looks like `getline(3)`, the caller should free the line after each call.' >> ${LOGFILENAME}
+          return 255
+        else
+          if [ "${RET2}" == "" ]
+          then
+            if [ "${RET0}" != "" ]
+            then
+              printf "%s" 'Failing basic tests'
+              echo 'Result: This get_next_line is failing basic tests, you should fix them before running this test.' >> ${LOGFILENAME}
+              echo "-----------------------------------" >> ${LOGFILENAME}
+              echo "Output of the test (Run 3 times in a row):" >> ${LOGFILENAME}
+              echo "${RET0}" >> ${LOGFILENAME}
+              echo "-----------------------------------" >> ${LOGFILENAME}
+              echo "Source file of this test (${GLOBAL_INSTALLDIR}/${SRCFILE}):" >> ${LOGFILENAME}
+              cat ${SRCFILE} >> ${LOGFILENAME}
+              return 1
+            else
+              printf "%s" "An error occured"
+            fi
+          else
+            printf "%s" 'Failing or not similar to `getline(3)`'
+            echo 'Result: The implementation of this get_next_line is not similar to `getline(3)` or is failing with unexpected errors.' >> ${LOGFILENAME}
+            echo "If a SIGABRT signal has been raised (see below), it is because the caller should not free the line after each call." >> ${LOGFILENAME}
+            echo "If something else is shown in output, it means that this get_next_line is failing and should be fixed." >> ${LOGFILENAME}
+            echo "-----------------------------------" >> ${LOGFILENAME}
+            echo "Output of the test (Run 3 times in a row):" >> ${LOGFILENAME}
+            echo "${RET0}" >> ${LOGFILENAME}
+            echo "${RET2}" >> ${LOGFILENAME}
+            echo "-----------------------------------" >> ${LOGFILENAME}
+            echo "Source file of this test (${GLOBAL_INSTALLDIR}/${SRCFILE}):" >> ${LOGFILENAME}
+            cat ${SRCFILE} >> ${LOGFILENAME}
+            return 255
+          fi
+        fi
+      else
+        printf "%s" "Cannot compile"
+        echo "${RET0}" >> ${LOGFILENAME}
+      fi
+      return 1
+    fi
+    printf "%s" "Not performed"
+    return 255
+  }
+
   function check_gnl_multiple_fd
   {
-    local GNL_LIBFT i j FILEN TITLEN RET0 errors fatal GNLID LOGFILENAME
+    local GNL_LIBFT_DIRECTORY i j FILEN TITLEN RET0 errors fatal GNLID LOGFILENAME
 
     if [ "${OPT_NO_GNLMULTIPLEFD}" == "0" ]
     then
@@ -220,16 +342,17 @@ then
       ${CMD_TOUCH} ${LOGFILENAME}
       check_create_tmp_dir
       check_gnl_create_header
-      GNL_LIBFT="${MYPATH}/libft"
+      GNL_LIBFT_DIRECTORY="${MYPATH}/libft"
       i=0
       j=0
       errors=0
       fatal=0
       ${CMD_RM} -f "./tmp/gnl11"
-      if [ -d "${GNL_LIBFT}" ]
+      if [ -d "${GNL_LIBFT_DIRECTORY}" ]
       then
-        make -C "${GNL_LIBFT}" >/dev/null 2>&1
-        RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT}" -lft -I "${GNL_LIBFT}/includes" ./srcs/gnl/gnl11.c -o ./tmp/gnl11 2>&1`
+        make -C "${GNL_LIBFT_DIRECTORY}" >/dev/null 2>&1
+        [ ${?} != 0 ] && echo "/!\ Failed to compile libft while running: make -C \"${GNL_LIBFT_DIRECTORY}\"" >> ${LOGFILENAME}
+        RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT_DIRECTORY}" -lft -I "${GNL_LIBFT_DIRECTORY}/includes" ./srcs/gnl/gnl11.c -o ./tmp/gnl11 2>&1`
       else
         RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" ./srcs/gnl/gnl11.c -o ./tmp/gnl11 2>&1`
       fi
@@ -245,8 +368,8 @@ then
           if [ "${RET0}" != "" ]
           then
             printf "%s" "Not supported"
-            echo "\n-----------------------------------" >> ${LOGFILENAME}
-            echo "Here is the main test ($(pwd)/srcs/gnl/gnl11.c):\n" >> ${LOGFILENAME}
+            echo "-----------------------------------" >> ${LOGFILENAME}
+            echo "Here is the main test (${GLOBAL_INSTALLDIR}/srcs/gnl/gnl11.c):" >> ${LOGFILENAME}
             cat "./srcs/gnl/gnl11.c" >> ${LOGFILENAME}
           else
             printf "%s" "An error occured"
@@ -264,7 +387,7 @@ then
 
   function check_gnl_leaks
   {
-    local GNL_LIBFT RET0 LOGFILENAME PROGNAME HEADERF VAL0 MACRONAME
+    local GNL_LIBFT_DIRECTORY RET0 LOGFILENAME PROGNAME HEADERF VAL0 MACRONAME
 
     if [ "${OPT_NO_LEAKS}" == "0" ]
     then
@@ -276,20 +399,22 @@ then
       HEADERF="${MYPATH}/get_next_line.h"
       if [ -f "${HEADERF}" ]
       then
-        GNL_LIBFT="${MYPATH}/libft"
+        GNL_LIBFT_DIRECTORY="${MYPATH}/libft"
         MACRONAME=$(check_gnl_get_macro_name "${HEADERF}")
         RET0=`cat "${HEADERF}" | grep define | grep "${MACRONAME}"`
         VAL0=`printf "%s" "${RET0}" | sed 's/[^0-9]*//g'`
         if [ $(printf "%d" "${VAL0}") -gt 11000 ]
         then
-          echo "Please use a smaller ${MACRONAME}!\nMaximum is 11000." > ${LOGFILENAME}
+          echo "Please use a smaller ${MACRONAME}!" > ${LOGFILENAME}
+          echo "Maximum is 11000." >> ${LOGFILENAME}
           printf "%s" "${MACRONAME} too big"
         else
           ${CMD_RM} -f "./tmp/gnl10"
-          if [ -d "${GNL_LIBFT}" ]
+          if [ -d "${GNL_LIBFT_DIRECTORY}" ]
           then
-            make -C "${GNL_LIBFT}" >${LOGFILENAME} 2>&1
-            RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT}" -lft -I "${GNL_LIBFT}/includes" ./srcs/gnl/gnl10.c -o ./tmp/gnl10 2>&1`
+            make -C "${GNL_LIBFT_DIRECTORY}" >/dev/null 2>&1
+            [ ${?} != 0 ] && echo "/!\ Failed to compile libft while running: make -C \"${GNL_LIBFT_DIRECTORY}\"" >> ${LOGFILENAME}
+            RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" -L"${GNL_LIBFT_DIRECTORY}" -lft -I "${GNL_LIBFT_DIRECTORY}/includes" ./srcs/gnl/gnl10.c -o ./tmp/gnl10 2>&1`
           else
             RET0=`${CMD_GCC} -Wall -Werror -Wextra -I ./tmp "${MYPATH}/get_next_line.c" ./srcs/gnl/gnl10.c -o ./tmp/gnl10 2>&1`
           fi
@@ -317,8 +442,8 @@ then
   {
     local GNLH
 
-    GNLH="$MYPATH/get_next_line.h"
-    echo "#include \"$GNLH\"" > ./tmp/gnl.h
+    GNLH="${MYPATH}/get_next_line.h"
+    echo "#include \"${GNLH}\"" > ./tmp/gnl.h
   }
 
   function check_gnl_bonus
@@ -328,31 +453,31 @@ then
     if [ "${OPT_NO_GNLONESTATIC}" == "0" ]
     then
       LOGFILENAME=.mystatic
-      $CMD_RM -f $LOGFILENAME
-      $CMD_TOUCH $LOGFILENAME
-      GNLC="$MYPATH/get_next_line.c"
-      if [ -f "$GNLC" ]
+      ${CMD_RM} -f ${LOGFILENAME}
+      ${CMD_TOUCH} ${LOGFILENAME}
+      GNLC="${MYPATH}/get_next_line.c"
+      if [ -f "${GNLC}" ]
       then
-        RET0=`awk 'BEGIN { OFS=""; BLOCK=0 } { if ($0 == "{") { BLOCK=1 } if ($0 == "}") { BLOCK=0 } if (BLOCK == 1) { if ($0 ~ /^[\t ]*static[\t ]/) { gsub(/^[\t ]*/, ""); print "line ", NR, ": ", $0 }}}' "$GNLC"`
-        TOTAL=`echo "$RET0" | awk 'END {print NR}'`
+        RET0=`awk 'BEGIN { OFS=""; BLOCK=0 } { if ($0 == "{") { BLOCK=1 } if ($0 == "}") { BLOCK=0 } if (BLOCK == 1) { if ($0 ~ /^[\t ]*static[\t ]/) { gsub(/^[\t ]*/, ""); print "line ", NR, ": ", $0 }}}' "${GNLC}"`
+        TOTAL=`echo "${RET0}" | awk 'END {print NR}'`
         if (( TOTAL > 1 ))
         then
           printf "%s" "${TOTAL} static variables found"
-          echo "$RET0" > $LOGFILENAME
+          echo "${RET0}" > ${LOGFILENAME}
         else
-          if [ "$RET0" == "" ]
+          if [ "${RET0}" == "" ]
           then
             printf "%s" "No static variable"
-            echo "No static var found" > $LOGFILENAME
+            echo "No static var found" > ${LOGFILENAME}
           else
             printf "%s" "${TOTAL} static variable"
-            echo "$RET0" > $LOGFILENAME
+            echo "${RET0}" > ${LOGFILENAME}
           fi
           return 0
         fi
       else
         printf "%s" "get_next_line.c not found"
-        echo "get_next_line.c: File Not Found" > $LOGFILENAME
+        echo "get_next_line.c: File Not Found" > ${LOGFILENAME}
       fi
       return 1
     fi
@@ -384,7 +509,12 @@ then
           if [ "${RET2}" == "" ]
           then
             printf "%s" "${MACRONAME} is defined with value: ${VAL0}, but seems to be used not properly"
-            echo "${MACRONAME} should be used as the third parameter of the function 'read' without any handling! read([*], [*], ${MACRONAME})\n\nCheck the line(s) where the function 'read' is used:\n$(cat "${MYPATH}/get_next_line.c" | grep -E '[^*]{2}.*read[ \t]*\(' | sed 's/^[ 	]*//g')\n\nNote: When multiple lines are used for calling 'read', this test fails!" > ${LOGFILENAME}
+            echo "${MACRONAME} should be used as the third parameter of the function 'read' without any handling! read([*], [*], ${MACRONAME})" > ${LOGFILENAME}
+            echo "" >> ${LOGFILENAME}
+            echo "Check the line(s) where the function 'read' is used:" >> ${LOGFILENAME}
+            echo "$(cat "${MYPATH}/get_next_line.c" | grep -E '[^*]{2}.*read[ \t]*\(' | sed 's/^[ 	]*//g')" >> ${LOGFILENAME}
+            echo "" >> ${LOGFILENAME}
+            echo "Note: When multiple lines are used for calling 'read', this test fails!" >> ${LOGFILENAME}
           else
             printf "%s" "${MACRONAME} is defined with value: ${VAL0}"
             echo "${MACRONAME} is defined with value: ${VAL0}" > ${LOGFILENAME}

--- a/srcs/gnl/gnl9_1.c
+++ b/srcs/gnl/gnl9_1.c
@@ -1,7 +1,5 @@
 #include <string.h>
 #include <stdio.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include "gnl.h"
 
 /*

--- a/srcs/gnl/gnl_to_free_or_not_to_free.c
+++ b/srcs/gnl/gnl_to_free_or_not_to_free.c
@@ -1,0 +1,53 @@
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "gnl.h"
+
+/*
+** reading 4 lines while freeing them
+*/
+
+int				main(void)
+{
+	char		*line;
+	int			fd;
+	int			ret;
+	int			count_lines;
+	char		*filename;
+	int			errors;
+
+	filename = "gnl_to_free_or_not_to_free.txt";
+	fd = open(filename, O_RDONLY);
+	if (fd > 2)
+	{
+		count_lines = 0;
+		errors = 0;
+		line = NULL;
+		while ((ret = get_next_line(fd, &line)) > 0)
+		{
+			if (count_lines == 0 && strcmp(line, "This is the first line") != 0)
+				errors++;
+			if (count_lines == 1 && strcmp(line, "This is the second one") != 0)
+				errors++;
+			if (count_lines == 2 && strcmp(line, "This is the third") != 0)
+				errors++;
+			if (count_lines == 3 && strcmp(line, "This is the last") != 0)
+				errors++;
+			count_lines++;
+			free(line);
+			if (count_lines > 50)
+				break ;
+		}
+		close(fd);
+		if (count_lines != 4)
+			printf("-> must have returned '1' four times instead of %d time(s)\n", count_lines);
+		if (errors > 0)
+			printf("-> must have read \"This is the first line\", \"This is the second one\", \"This is the third\", \"This is the last\".\n");
+		if (count_lines == 4 && errors == 0)
+			printf("OK");
+	}
+	else
+		printf("An error occured while opening file %s\n", filename);
+	return (0);
+}

--- a/srcs/gnl/gnl_to_free_or_not_to_free.txt
+++ b/srcs/gnl/gnl_to_free_or_not_to_free.txt
@@ -1,0 +1,4 @@
+This is the first line
+This is the second one
+This is the third
+This is the last


### PR DESCRIPTION
Proposed test for noticing about the memory management behavior of get_next_line.

This test never fails or succeed because the subject does not describe the expected behavior:
- The caller should free the lines after each call (In my opinion it is the the preferred behavior, similar to `getline(3)`)
- The caller must not free the lines after each call, get_next_line do it itself if necessary

![image](https://user-images.githubusercontent.com/8960628/51090053-78191400-1776-11e9-8f9d-e9b11a3bebef.png)
