### PR TITLE
fix #115 using inode + last modification date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ maintest/
 .my*
 *~
 srcs/gnl/gnl.h
+srcs/get_inode/obj/
+srcs/get_inode/get_inode
 tmp/*
 .idea

--- a/42FileChecker.sh
+++ b/42FileChecker.sh
@@ -103,6 +103,7 @@ source includes/utils/utils.sh
 source includes/utils/utils_auteur.sh
 source includes/utils/utils_authorized_functions.sh
 source includes/utils/utils_configure.sh
+source includes/utils/utils_get_inode.sh
 source includes/utils/utils_exit.sh
 source includes/utils/utils_fileexists.sh
 source includes/utils/utils_forbidden_functions.sh

--- a/includes/utils/utils_get_inode.sh
+++ b/includes/utils/utils_get_inode.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "$FILECHECKER_SH" == "1" ]
+then
+
+  function utils_get_inode
+  {
+    local FILEPATH GETINODEDIR GETINODEEXE LOGFILENAME
+
+    FILEPATH="${1}"
+    GETINODEDIR="${GLOBAL_INSTALLDIR}/srcs/get_inode"
+    GETINODEEXE="${GETINODEDIR}/get_inode"
+    LOGFILENAME="${2}"
+    ${CMD_RM}  -f ${LOGFILENAME}
+    ${CMD_TOUCH} ${LOGFILENAME}
+    make -C "${GETINODEDIR}" 1>${LOGFILENAME} 2>&1 || return 1
+    "${GETINODEEXE}" "${FILEPATH}" 2>${LOGFILENAME} || return 1
+    return ${?}
+  }
+
+fi

--- a/srcs/get_inode/Makefile
+++ b/srcs/get_inode/Makefile
@@ -1,0 +1,31 @@
+NAME = get_inode
+
+### PATH ###
+SRCS_PATH = ./
+OBJ_PATH  = ./obj/
+
+FLAGS = -Wall -Werror -Wextra
+
+SRCS_NAME = main.c
+
+SRCS = $(addprefix $(SRCS_PATH), $(SRCS_NAME))
+OBJ = $(addprefix $(OBJ_PATH), $(SRCS_NAME:.c=.o))
+
+all: $(NAME)
+
+$(NAME): $(OBJ)
+	@gcc $(FLAGS) $(OBJ) -o $(NAME)
+
+$(OBJ_PATH)%.o: $(SRCS_PATH)%.c
+	@mkdir -p obj
+	@gcc -c $(FLAGS) $< -o $@
+
+clean:
+	@/bin/rm -rf $(OBJ_PATH)
+
+fclean: clean
+	@/bin/rm -rf $(NAME)
+
+re: fclean all
+
+.PHONY: all, clean, fclean, re

--- a/srcs/get_inode/main.c
+++ b/srcs/get_inode/main.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <stdlib.h>
+
+/*
+**  retrieve inode of the given file
+*/
+
+static char*	formatdate(char* str, time_t val)
+{
+	strftime(str, 14, "%Y%m%d%H%M%S", localtime(&val));
+	return str;
+}
+
+int				main(int argc, char **argv)
+{
+	int			fd;
+	int			ret;
+	struct stat	st;
+	char		date[14];
+
+	if (argc != 2)
+		return (1);
+	fd = open(argv[0], O_RDONLY);
+	if (fd < 0)
+		return (2);
+	ret = fstat(fd, &st);
+	close(fd);
+	if (ret < 0)
+		return (3);
+	printf("%llu/%s", st.st_ino, formatdate(date, st.st_mtime));
+	return (0);
+}


### PR DESCRIPTION
[Makefile rules]
The purpose of this PR is to fix issues with inode unchanged.
Now 42FC also checks the last modification timestamp in addition to inode of the lib/binary.