### PR TITLE
Implemented PFT as an external module for ft_printf

### DIFF
--- a/42FileChecker.sh
+++ b/42FileChecker.sh
@@ -43,6 +43,7 @@ OPT_NO_TIMEOUT=0
 OPT_NO_NORMINETTE=0
 OPT_NO_AUTEUR=0
 OPT_NO_MOULITEST=0
+OPT_NO_PFT=0
 OPT_NO_LIBFTUNITTEST=0
 OPT_NO_FILLITCHECKER=0
 OPT_NO_MAINTEST=0
@@ -79,6 +80,7 @@ do
     "--no-auteur") OPT_NO_AUTEUR=1 ;;
     "--no-author") OPT_NO_AUTEUR=1 ;;
     "--no-moulitest") OPT_NO_MOULITEST=1 ;;
+    "--no-pft") OPT_NO_PFT=1 ;;
     "--no-libftunittest") OPT_NO_LIBFTUNITTEST=1 ;;
     "--no-fillitchecker") OPT_NO_FILLITCHECKER=1 ;;
     "--no-maintest") OPT_NO_MAINTEST=1 ;;
@@ -131,6 +133,7 @@ source includes/external_repositories/external_repository_fillit_checker.sh
 source includes/external_repositories/external_repository_libftunittest.sh
 source includes/external_repositories/external_repository_maintest.sh
 source includes/external_repositories/external_repository_moulitest.sh
+source includes/external_repositories/external_repository_pft.sh
 source includes/projects/fillit/fillit_main.sh
 source includes/projects/ft_ls/ft_ls_main.sh
 source includes/projects/ft_printf/ft_printf_main.sh

--- a/includes/external_repositories/external_repository_pft.sh
+++ b/includes/external_repositories/external_repository_pft.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+if [ "$FILECHECKER_SH" == "1" ]
+then
+
+  function check_pft_php_installed
+  {
+    local RET
+    RET=`php -v 2>/dev/null | grep -c "PHP" | tr -d " \t"`
+    if [ "$RET" == "0" ] ; then
+      return 0
+    fi
+    return 1
+  }
+
+  function pft_append_disabled_tests_list
+  {
+    echo "\n" >> .mypft
+    echo "==========================" >> .mypft
+    echo "  Disabled Tests" >> .mypft
+    echo "==========================" >> .mypft
+    echo "" >> .mypft
+    ${PFT_DIR}"/show-disabled-tests" >> .mypft
+  }
+
+  function check_pft
+  {
+    local RET0 RET1 TOTAL MYPATH PASSED TOTAL
+    if [ "$OPT_NO_PFT" == "0" ] ; then
+      rm -f .mypft
+      check_pft_php_installed
+      if ! [ "${?}" -eq 1 ] ; then
+        printf "%s" "Requires PHP"
+        return 255
+      fi
+      if ! [ -d "${PFT_DIR}" ] ; then
+        printf "%s" "Not installed"
+        return 1
+      fi
+      MYPATH=$(get_config "ft_printf")
+      make -C "${PFT_DIR}" re 1> .mypft 2>&1
+      # Check compilation
+      RET1=`cat .mypft`
+      RET0=`echo "$RET1" | grep -c "error"`
+      if ! [ "$RET0" == "0" ] ; then
+        printf "%s" "Cannot compile"
+        return 1
+      fi
+      # Run tests
+      "${PFT_DIR}/test" 1> .mypft-tmp1 2>&1
+        # Analyze results
+      RET1=`cat .mypft-tmp1`
+      RET0=`echo "$RET1" | grep "Tests completed."`
+      if [ "$RET0" == "" ] ; then
+        printf "%s" "PFT has aborted"
+        return 1
+      fi
+      # Get test results summary
+      PASSED=`echo "$RET0" | cut -d ' ' -f 3 | cut -d '/' -f 1`
+      TOTAL=`echo "$RET0" | cut -d ' ' -f 3 | cut -d '/' -f 2`
+      printf "%s" "${PASSED}/${TOTAL} tests passed"
+      if [ "$PASSED" == "$TOTAL" ] ; then
+        # Output test summary
+        cat .mypft-tmp1 > .mypft
+        pft_append_disabled_tests_list
+        rm .mypft-tmp1
+        check_cleanlog .mypft
+        return 0
+      fi
+      # Output detailed tests results and test summary
+      cat .mypft-tmp1 | head -n 4 > .mypft
+      echo "\nResults of failed tests:\n\n" >> .mypft
+      cat .pft_results.txt >> .mypft 2>/dev/null
+      rm .pft_results.txt 2>/dev/null
+      echo "\nTest Summary:" >> .mypft
+      cat .mypft-tmp1 >> .mypft
+      rm .mypft-tmp1
+      pft_append_disabled_tests_list
+      check_cleanlog .mypft
+      return 1
+    fi
+    printf "%s" "Not performed"
+    return 255
+  }
+
+  function configure_pft
+  {
+    [ "$OPT_NO_PFT" != "0" ] && return
+    check_pft_php_installed
+    if ! [ "${?}" -eq 1 ] ; then
+      return
+    fi
+    [ -d "${PFT_DIR}" ] || return
+    php ${PFT_DIR}/configurations/42fc/configure_42fc.php $1
+  }
+
+fi;

--- a/includes/projects/ft_printf/ft_printf_main.sh
+++ b/includes/projects/ft_printf/ft_printf_main.sh
@@ -13,7 +13,7 @@ then
   declare CONF_FT_PRINTF_TESTS="CHK_FT_PRINTF"
   declare CONF_FT_PRINTF_FORBIDDENFUNCS="CHK_FT_PRINTF_AUTHORIZED_FUNCS"
 
-  declare -a CHK_FT_PRINTF='( "check_author" "author file" "check_norme" "norminette" "check_ft_printf_makefile" "makefile" "check_ft_printf_forbidden_func" "forbidden functions" "check_ft_printf_basictests" "basic tests" "check_ft_printf_bastardtests" "undefined behavior tests" "check_ft_printf_leaks" "leaks" "check_ft_printf_speedtest" "speed test" "check_ft_printf_moulitest" "moulitest (${MOULITEST_URL})" )'
+  declare -a CHK_FT_PRINTF='( "check_author" "author file" "check_norme" "norminette" "check_ft_printf_makefile" "makefile" "check_ft_printf_forbidden_func" "forbidden functions" "check_ft_printf_basictests" "basic tests" "check_ft_printf_bastardtests" "undefined behavior tests" "check_ft_printf_leaks" "leaks" "check_ft_printf_speedtest" "speed test" "check_ft_printf_moulitest" "moulitest (${MOULITEST_URL})" "check_ft_printf_pft" "PFT (${PFT_URL})" )'
 
   function check_project_ft_printf_main
   {
@@ -22,6 +22,13 @@ then
     if [ "${OPT_NO_MOULITEST}" == "0" ]
     then
       check_update_external_repository "moulitest" "${MOULITEST_URL}" "${MOULITEST_DIR}"
+      case "${LOCAL_UPDATE_RETURN}" in
+        "exit") main; return ;;
+      esac
+    fi
+    if [ "${OPT_NO_PFT}" == "0" ]
+    then
+      check_update_external_repository "pft" "${PFT_URL}" "${PFT_DIR}"
       case "${LOCAL_UPDATE_RETURN}" in
         "exit") main; return ;;
       esac
@@ -79,6 +86,7 @@ then
       "${CMD_OPEN} .myleaks" "more info: leaks"\
       "${CMD_OPEN} .myspeedtest" "more info: speed test"\
       "${CMD_OPEN} .mymoulitest" "more info: moulitest"\
+      "${CMD_OPEN} .mypft" "more info: PFT"\
       "_"\
       "${CMD_OPEN} https://github.com/jgigault/42FileChecker/issues/new" "REPORT A BUG ON 42FILECHECKER"\
       "${CMD_OPEN} ${MOULITEST_URL}/issues/new" "REPORT A BUG ON MOULITEST"\
@@ -386,6 +394,18 @@ then
     if [ "$OPT_NO_MOULITEST" == "0" ]
     then
       check_moulitest "ft_printf"
+      return "${?}"
+    fi
+    printf "%s" "Not performed"
+    return 255
+  }
+
+  function check_ft_printf_pft
+  {
+    if [ "$OPT_NO_PFT" == "0" ]
+    then
+      configure_pft "${MYPATH}"
+      check_pft
       return "${?}"
     fi
     printf "%s" "Not performed"

--- a/includes/utils/utils.sh
+++ b/includes/utils/utils.sh
@@ -55,6 +55,8 @@ then
   CMD_OPEN=`command -v xdg-open 2>/dev/null || command -v open 2>/dev/null || echo -n 'open'`
   MOULITEST_URL="https://github.com/yyang42/moulitest_42projects"
   MOULITEST_DIR="moulitest_42projects"
+  PFT_URL="https://github.com/gavinfielder/pft"
+  PFT_DIR="pft"
   LIBFTUNITTEST_URL="https://github.com/alelievr/libft-unit-test"
   LIBFTUNITTEST_DIR="libft-unit-test"
   EXTERNAL_REPOSITORY_FILLITCHECKER_URL="https://github.com/anisg/fillit_checker"


### PR DESCRIPTION
I suspect this will have to be either rebased or at least reopened after the previous pull request is merged, but this can be open for discussion.

PFT is a tester I developed shortly after the ft_printf subject changed and is semi-popular on the Fremont and Moscow campuses. It's a heavier load than moulitest, but it's rigorous and adds test cases, especially when it comes to flag combinations. It also offers a more rational way of testing handling of undefined behavior in that it automatically passes tests with the `nocrash` tag provided ft_printf does not segfault or otherwise terminate abnormally.

I prepared a minimal ft_printf specification and corresponding configuration of PFT for 42FileChecker, refer to [https://github.com/gavinfielder/pft/wiki/PFT-in-42FileChecker](https://github.com/gavinfielder/pft/wiki/PFT-in-42FileChecker)
